### PR TITLE
Update validateAuthGetRoute.js with more descript error if get request is made without enableGetAPIRoutes enabled in the .env

### DIFF
--- a/routes/validateAuthGetRoute.js
+++ b/routes/validateAuthGetRoute.js
@@ -2,7 +2,7 @@ require("dotenv").config();
 
 const authGetAPIRoute = (req, res, next) => {
   if (process.env.enableGetAPIRoutes == "false" || !process.env.enableGetAPIRoutes) {
-    res.json("Unknown key, are get api routes enabled on the server (enableGetAPIRoutes) in .env?");
+    res.json("Unknown key, are get api routes enabled on the server? (enableGetAPIRoutes=true) in .env?");
   } else {
     return next();
   }


### PR DESCRIPTION
This middleware function can be applied to any get request that a user should not be able to access in the end product of the site, this middleware ensures that even if the code somehow slips into production as long as the .env var is set to false users cannot just make a get request for the full database or whatever data is being returned from the route handler function, just set app.get("/test/route1", authGetAPIRoute, (req, res) => { do all the stuff you need to do to get the data you need or whatever, authGetAPIRoute is just whatever it was named when const authGetAPIRoute = require("../routes/validateAuthGetRoute")-ing })