### PR TITLE
Added auto login after successful register

### DIFF
--- a/models/Lepo.js
+++ b/models/Lepo.js
@@ -1,43 +1,40 @@
-const { Model, DataTypes } = require('sequelize');
-const sequelize = require('../db/sequelizeConn');
+const { Model, DataTypes } = require("sequelize");
+const sequelize = require("../db/sequelizeConn");
 
-class Lepo extends Model { }
+class Lepo extends Model {}
 
 Lepo.init(
-    {
-        id: {
-            type: DataTypes.INTEGER,
-            allowNull: false,
-            primaryKey: true,
-            autoIncrement: true,
-        },
-        region: {
-            type: DataTypes.STRING,
-        },
-        Name: {
-            type: DataTypes.STRING,
-        },
-        DESC: {
-            type: DataTypes.STRING,
-        },
-        Images: {
-            type: DataTypes.BLOB,
-        },
-        Facts: {
-            types: DataTypes.STRING,
-        },
-        Comments: {
-            types: DataTypes.STRING,
-        },
-       
-    }, {
-        sequelize, 
-        freezeTableName: true,
-        modelName: "Lepo", 
-    });
-    
-   
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    region: {
+      type: DataTypes.STRING,
+    },
+    Name: {
+      type: DataTypes.STRING,
+    },
+    DESC: {
+      type: DataTypes.STRING,
+    },
+    Images: {
+      type: DataTypes.BLOB,
+    },
+    Facts: {
+      types: DataTypes.STRING,
+    },
+    Comments: {
+      types: DataTypes.STRING,
+    },
+  },
+  {
+    sequelize,
+    freezeTableName: true,
+    modelName: "Lepo",
+  }
+);
 
-module.export = Lepo; 
-
-
+module.export = Lepo;

--- a/public/scripts/register.js
+++ b/public/scripts/register.js
@@ -11,8 +11,6 @@ const submitBtn = document.getElementById("register_submitBtn");
 
 const handleSubmit = async (e) => {
   await e.preventDefault();
-  errorDisplay.setAttribute("active", "false");
-  errorDisplay.innerHTML = "";
   try {
     if (!usernameEl || usernameEl.value == "") throw new Error("Username cannot be blank");
     if (!firstNameEl || firstNameEl.value == "") throw new Error("First name cannot be blank");
@@ -41,10 +39,28 @@ const handleSubmit = async (e) => {
 
     const jsonRes = await res.json();
 
-    if (jsonRes.err)
+    if (jsonRes.err) {
       throw new Error(`${jsonRes.err.substring(0, 1).toUpperCase()}${jsonRes.err.substring(1)}`);
+    }
 
-    console.log(jsonRes);
+    const loginRes = await fetch("http://localhost:3000/api/user/login", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ username: usernameEl.value, password: passwordEl.value }),
+    });
+
+    console.log(loginRes);
+
+    const loginJson = await loginRes.json();
+
+    if (loginJson.err) throw new Error(loginJson.err);
+
+    errorDisplay.setAttribute("active", "false");
+    errorDisplay.innerHTML = "";
+
+    window.location.href = "/";
   } catch (err) {
     errorDisplay.setAttribute("active", "true");
     errorDisplay.innerHTML = err.message;
@@ -114,6 +130,9 @@ const checkIfExistsInDb = async (type, e) => {
 
   if (json == "Valid") {
     e.target.parentNode.children[1].innerHTML = "done";
+    return;
+  } else {
+    e.target.parentNode.children[1].innerHTML = "close";
     return;
   }
 };

--- a/routes/user/checkIfExists.js
+++ b/routes/user/checkIfExists.js
@@ -16,7 +16,7 @@ router.get("/", async (req, res) => {
 
     res.json("Valid");
   } catch (err) {
-    res.json(err.message);
+    res.json({ err: err.message });
   }
 });
 

--- a/views/layouts/default.handlebars
+++ b/views/layouts/default.handlebars
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
Added some fixes for small errors like shebang <!DOCTYPE html> not being included in the layout page, an X icon not being displayed on a **valid** username/email that is not available on the register page, and a simple reformat of Lepo.js to follow prettier formatter conventions (to make this automatic, hit cmd/ctrl + , on mac/win to open VS code settings, search for formatter, and select prettier as default if you don't have it selected (if it's not installed go to extensions and install it), then check "format on save" if you'd like your files to auto format to how prettier autoformats + the rules in the .prettierrc.json in the project root). Register route now throws an {err: "Verification failed"} obj rather than just a string literal of "Valid" or "Verification on isEmail failed", thus errors can more easily be separated after fetching the route just by checking if rtn.err is an existent value. Finally, when a user is successfully registered in the system, a new fetch request is made to the login route to try and log in the user based on the entered information on the register page (as long as the logic is awaited correctly, this functionality should always be registerRoute => res => if(err) throw err to be caught => attempt to login => res => if(err) throw error else redirect to homepage).